### PR TITLE
New RabbitMQ 3.11, hotfixes and Erlang Patches

### DIFF
--- a/.github/workflows/ci-windows-2019.yaml
+++ b/.github/workflows/ci-windows-2019.yaml
@@ -1,0 +1,123 @@
+#######################################################
+# CI Build pipeline YAML for Windows 2019 based builds 
+#######################################################
+
+name: ci-windows-2019
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - releases/**  # in future to release from release branch
+    paths:
+      - rabbitmq/windows/**   # build only where an update to windows folder 
+      - .github/workflows/ci-windows-latest.yaml
+
+jobs:
+   # TO-DO: Could simplify steps further, but probably in next iteration 
+ # For now a quick approach 
+  build-docker-ltsc2019:
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+       # Build and Push 3.11.2
+      - name: Build the Docker image 3.11.2
+        run: |
+          docker build . --file ./rabbitmq/windows/3.11.2/Dockerfile --tag micdenny/rabbitmq-windows:ltsc2019-latest --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.11.2
+        run: |
+          docker tag micdenny/rabbitmq-windows:ltsc2019-latest micdenny/rabbitmq-windows:3.11.2-ltsc2019
+          docker tag micdenny/rabbitmq-windows:ltsc2019-latest micdenny/rabbitmq-windows:3.11.2-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:ltsc2019-latest
+          docker push micdenny/rabbitmq-windows:3.11.2-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.11.2-servercore-ltsc2019
+
+       # Build and Push 3.11.0
+      - name: Build the Docker image 3.11.0
+        run: |
+          docker build . --file ./rabbitmq/windows/3.11.0/Dockerfile --tag micdenny/rabbitmq-windows:3.11.0-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.11.0
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.11.0-ltsc2019 micdenny/rabbitmq-windows:3.11.0-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.11.0-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.11.0-servercore-ltsc2019
+          
+      # Build and Push 3.10.7
+      - name: Build the Docker image 3.10.7
+        run: |
+          docker build . --file ./rabbitmq/windows/3.10.7/Dockerfile --tag micdenny/rabbitmq-windows:3.10.7-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.10.7
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.10.7-ltsc2019 micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.10.7-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2019
+
+      # Build and Push 3.9.24
+      - name: Build the Docker image 3.9.24
+        run: |
+          docker build . --file ./rabbitmq/windows/3.9.24/Dockerfile --tag micdenny/rabbitmq-windows:3.9.24-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.9.24
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.9.24-ltsc2019 micdenny/rabbitmq-windows:3.9.24-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.9.24-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.9.24-servercore-ltsc2019
+          
+          
+      # Build and Push 3.9.22
+      - name: Build the Docker image 3.9.22
+        run: |
+          docker build . --file ./rabbitmq/windows/3.9.22/Dockerfile --tag micdenny/rabbitmq-windows:3.9.22-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.9.22
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.9.22-ltsc2019 micdenny/rabbitmq-windows:3.9.22-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.9.22-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.9.22-servercore-ltsc2019
+
+      # Build and Push 3.8.35
+      - name: Build the Docker image 3.8.35
+        run: |
+          docker build . --file ./rabbitmq/windows/3.8.35/Dockerfile --tag micdenny/rabbitmq-windows:3.8.35-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.8.35
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.8.35-ltsc2019 micdenny/rabbitmq-windows:3.8.35-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.8.35-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.8.35-servercore-ltsc2019
+
+      # Build and Push 3.8.16
+      - name: Build the Docker image 3.8.16
+        run: |
+          docker build . --file ./rabbitmq/windows/3.8.16/Dockerfile --tag micdenny/rabbitmq-windows:3.8.16 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.8.16
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.8.16 micdenny/rabbitmq-windows:3.8.16-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.8.16
+          docker push micdenny/rabbitmq-windows:3.8.16-servercore-ltsc2019
+
+      # Build and Push 3.6.9
+      - name: Build the Docker image 3.6.9
+        run: |
+          docker build . --file ./rabbitmq/windows/3.6.9/Dockerfile --tag micdenny/rabbitmq-windows:3.6.9 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.6.9
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.6.9 micdenny/rabbitmq-windows:3.6.9-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.6.9
+          docker push micdenny/rabbitmq-windows:3.6.9-servercore-ltsc2019
+          
+      # Build and Push 3.6.12
+      - name: Build the Docker image 3.6.12
+        run: |
+          docker build . --file ./rabbitmq/windows/3.6.12/Dockerfile --tag micdenny/rabbitmq-windows:3.6.12 --build-arg SERVER_VERSION=ltsc2019
+      - name: Publish to DockerHub 3.6.12
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.6.12 micdenny/rabbitmq-windows:3.6.12-servercore-ltsc2019
+          docker push micdenny/rabbitmq-windows:3.6.12
+          docker push micdenny/rabbitmq-windows:3.6.12-servercore-ltsc2019

--- a/.github/workflows/ci-windows-latest.yaml
+++ b/.github/workflows/ci-windows-latest.yaml
@@ -1,3 +1,6 @@
+#######################################################
+# CI Build pipeline YAML for Windows 2022 based builds 
+#######################################################
 name: ci-windows-latest
 
 on:
@@ -25,18 +28,61 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
+
+      # Build and Push 3.11.2
+      - name: Build the Docker image 3.11.2
+        run: |
+          docker build . --file ./rabbitmq/windows/3.11.2/Dockerfile --tag micdenny/rabbitmq-windows:latest --build-arg SERVER_VERSION=ltsc2022
+      - name: Publish to DockerHub 3.11.2
+        run: |
+          docker tag micdenny/rabbitmq-windows:latest micdenny/rabbitmq-windows:3.11.2
+          docker tag micdenny/rabbitmq-windows:latest micdenny/rabbitmq-windows:ltsc2022-latest
+          docker tag micdenny/rabbitmq-windows:latest micdenny/rabbitmq-windows:3.11.2-servercore-ltsc2022
+          docker push micdenny/rabbitmq-windows:latest
+          docker push micdenny/rabbitmq-windows:ltsc2022-latest
+          docker push micdenny/rabbitmq-windows:3.11.2
+          docker push micdenny/rabbitmq-windows:3.11.2-servercore-ltsc2022
+
+       # Build and Push 3.11.0
+      - name: Build the Docker image 3.11.0
+        run: |
+          docker build . --file ./rabbitmq/windows/3.11.0/Dockerfile --tag micdenny/rabbitmq-windows:3.11.0 --build-arg SERVER_VERSION=ltsc2022
+      - name: Publish to DockerHub 3.11.0
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.11.0 micdenny/rabbitmq-windows:3.11.0-servercore-ltsc2022
+          docker push micdenny/rabbitmq-windows:3.11.0
+          docker push micdenny/rabbitmq-windows:3.11.0-servercore-ltsc2022
+
+      # Build and Push 3.10.10
+      - name: Build the Docker image 3.10.10
+        run: |
+          docker build . --file ./rabbitmq/windows/3.10.10/Dockerfile --tag micdenny/rabbitmq-windows:3.10.10 --build-arg SERVER_VERSION=ltsc2022
+      - name: Publish to DockerHub 3.10.10
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.10.10 micdenny/rabbitmq-windows:3.10.10-servercore-ltsc2022
+          docker push micdenny/rabbitmq-windows:3.10.10
+          docker push micdenny/rabbitmq-windows:3.10.10-servercore-ltsc2022
 
       # Build and Push 3.10.7
       - name: Build the Docker image 3.10.7
         run: |
-          docker build . --file ./rabbitmq/windows/3.10.7/Dockerfile --tag micdenny/rabbitmq-windows:latest --build-arg SERVER_VERSION=ltsc2022
+          docker build . --file ./rabbitmq/windows/3.10.7/Dockerfile --tag micdenny/rabbitmq-windows:3.10.7 --build-arg SERVER_VERSION=ltsc2022
       - name: Publish to DockerHub 3.10.7
         run: |
-          docker tag micdenny/rabbitmq-windows:latest micdenny/rabbitmq-windows:3.10.7
-          docker tag micdenny/rabbitmq-windows:latest micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2022
-          docker push micdenny/rabbitmq-windows:latest
+          docker tag micdenny/rabbitmq-windows:3.10.7 micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2022
           docker push micdenny/rabbitmq-windows:3.10.7
           docker push micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2022
+
+      # Build and Push 3.9.24
+      - name: Build the Docker image 3.9.24
+        run: |
+          docker build . --file ./rabbitmq/windows/3.9.24/Dockerfile --tag micdenny/rabbitmq-windows:3.9.24 --build-arg SERVER_VERSION=ltsc2022
+      - name: Publish to DockerHub 3.9.24
+        run: |
+          docker tag micdenny/rabbitmq-windows:3.9.24 micdenny/rabbitmq-windows:3.9.24-servercore-ltsc2022
+          docker push micdenny/rabbitmq-windows:3.9.24
+          docker push micdenny/rabbitmq-windows:3.9.24-servercore-ltsc2022
           
       # Build and Push 3.9.22
       - name: Build the Docker image 3.9.22
@@ -90,74 +136,4 @@ jobs:
           docker push micdenny/rabbitmq-windows:3.6.12-servercore-ltsc2022
         
 
-  build-docker-ltsc2019:
-    runs-on: windows-2019
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
-       # Build and Push 3.10.7
-      - name: Build the Docker image 3.10.7
-        run: |
-          docker build . --file ./rabbitmq/windows/3.10.7/Dockerfile --tag micdenny/rabbitmq-windows:3.10.7-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.10.7
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.10.7-ltsc2019 micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.10.7-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.10.7-servercore-ltsc2019
-          
-      # Build and Push 3.9.22
-      - name: Build the Docker image 3.9.22
-        run: |
-          docker build . --file ./rabbitmq/windows/3.9.22/Dockerfile --tag micdenny/rabbitmq-windows:3.9.22-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.9.22
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.9.22-ltsc2019 micdenny/rabbitmq-windows:3.9.22-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.9.22-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.9.22-servercore-ltsc2019
-
-      # Build and Push 3.8.35
-      - name: Build the Docker image 3.8.35
-        run: |
-          docker build . --file ./rabbitmq/windows/3.8.35/Dockerfile --tag micdenny/rabbitmq-windows:3.8.35-ltsc2019 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.8.35
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.8.35-ltsc2019 micdenny/rabbitmq-windows:3.8.35-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.8.35-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.8.35-servercore-ltsc2019
-
-      # Build and Push 3.8.16
-      - name: Build the Docker image 3.8.16
-        run: |
-          docker build . --file ./rabbitmq/windows/3.8.16/Dockerfile --tag micdenny/rabbitmq-windows:3.8.16 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.8.16
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.8.16 micdenny/rabbitmq-windows:3.8.16-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.8.16
-          docker push micdenny/rabbitmq-windows:3.8.16-servercore-ltsc2019
-
-      # Build and Push 3.6.9
-      - name: Build the Docker image 3.6.9
-        run: |
-          docker build . --file ./rabbitmq/windows/3.6.9/Dockerfile --tag micdenny/rabbitmq-windows:3.6.9 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.6.9
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.6.9 micdenny/rabbitmq-windows:3.6.9-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.6.9
-          docker push micdenny/rabbitmq-windows:3.6.9-servercore-ltsc2019
-          
-      # Build and Push 3.6.12
-      - name: Build the Docker image 3.6.12
-        run: |
-          docker build . --file ./rabbitmq/windows/3.6.12/Dockerfile --tag micdenny/rabbitmq-windows:3.6.12 --build-arg SERVER_VERSION=ltsc2019
-      - name: Publish to DockerHub 3.6.12
-        run: |
-          docker tag micdenny/rabbitmq-windows:3.6.12 micdenny/rabbitmq-windows:3.6.12-servercore-ltsc2019
-          docker push micdenny/rabbitmq-windows:3.6.12
-          docker push micdenny/rabbitmq-windows:3.6.12-servercore-ltsc2019
+  

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,7 +6,10 @@
 - [`3.8.35`,`3.8.35-servercore-ltsc2019`,`3.8.35-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.8.35/Dockerfile)
 - [`3.9.8`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.9.8/Dockerfile)
 - [`3.9.22`,`3.9.22-servercore-ltsc2019`,`3.9.22-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.9.22/Dockerfile)
+- [`3.9.24`,`3.9.24-servercore-ltsc2019`,`3.9.24-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.9.24/Dockerfile)
 - [`3.10.7`,`3.10.7-servercore-ltsc2019`,`3.10.7-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.10.7/Dockerfile)
+- [`3.10.10`,`3.10.10-servercore-ltsc2019`,`3.10.10-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.10.10/Dockerfile)
+- [`3.11.2`,`3.11.2-servercore-ltsc2019`,`3.11.2-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.11.2/Dockerfile)
 - [`latest`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/latest/Dockerfile)
 
 # What is RabbitMQ?

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -10,7 +10,7 @@
 - [`3.10.7`,`3.10.7-servercore-ltsc2019`,`3.10.7-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.10.7/Dockerfile)
 - [`3.10.10`,`3.10.10-servercore-ltsc2019`,`3.10.10-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.10.10/Dockerfile)
 - [`3.11.2`,`3.11.2-servercore-ltsc2019`,`3.11.2-servercore-ltsc2022`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/3.11.2/Dockerfile)
-- [`latest`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/latest/Dockerfile)
+- [`latest`,`ltsc2019-latest`,`ltsc2022-latest`](https://github.com/micdenny/docker-samples/blob/master/rabbitmq/windows/latest/Dockerfile)
 
 # What is RabbitMQ?
 

--- a/rabbitmq/windows/3.10.10/Dockerfile
+++ b/rabbitmq/windows/3.10.10/Dockerfile
@@ -2,13 +2,13 @@
 ARG SERVER_VERSION='ltsc2022'  
 FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
-LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.7"
+LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.10"
 
 # ERLANG_HOME: erlang will install to this location and rabbitmq will use this environment variable to locate it
 # RABBITMQ_VERSION: rabbitmq version used in download url and to rename folder extracted from zip file
 # RABBITMQ_CONFIG_FILE: tell rabbitmq where to find our custom config file
 ENV ERLANG_HOME="c:\\erlang" \
-    RABBITMQ_VERSION="3.10.7" \
+    RABBITMQ_VERSION="3.10.10" \
     RABBITMQ_CONFIG_FILE="c:\\rabbitmq.conf"
 
 # setup powershell options for RUN commands

--- a/rabbitmq/windows/3.11.0/Dockerfile
+++ b/rabbitmq/windows/3.11.0/Dockerfile
@@ -2,13 +2,13 @@
 ARG SERVER_VERSION='ltsc2022'  
 FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
-LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.7"
+LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.11.0"
 
 # ERLANG_HOME: erlang will install to this location and rabbitmq will use this environment variable to locate it
 # RABBITMQ_VERSION: rabbitmq version used in download url and to rename folder extracted from zip file
 # RABBITMQ_CONFIG_FILE: tell rabbitmq where to find our custom config file
 ENV ERLANG_HOME="c:\\erlang" \
-    RABBITMQ_VERSION="3.10.7" \
+    RABBITMQ_VERSION="3.11.0" \
     RABBITMQ_CONFIG_FILE="c:\\rabbitmq.conf"
 
 # setup powershell options for RUN commands
@@ -19,7 +19,7 @@ EXPOSE 5672 15672
 # download and install erlang using silent install option, and remove installer when done
 # download and extract rabbitmq, and remove zip file when done
 # remove version from rabbitmq folder name
-RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_24.3.4.6.exe" -OutFile "c:\\erlang_install.exe" ; \
+RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_25.1.1.exe" -OutFile "c:\\erlang_install.exe" ; \
         Start-Process -Wait -FilePath "c:\\erlang_install.exe" -ArgumentList /S, /D=$env:ERLANG_HOME ; \
         Remove-Item -Force -Path "C:\\erlang_install.exe" ; \
     Invoke-WebRequest -Uri "https://github.com/rabbitmq/rabbitmq-server/releases/download/v$env:RABBITMQ_VERSION/rabbitmq-server-windows-$env:RABBITMQ_VERSION.zip" -OutFile "c:\\rabbitmq.zip" ; \

--- a/rabbitmq/windows/3.11.2/Dockerfile
+++ b/rabbitmq/windows/3.11.2/Dockerfile
@@ -2,13 +2,13 @@
 ARG SERVER_VERSION='ltsc2022'  
 FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
-LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.7"
+LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.11.2"
 
 # ERLANG_HOME: erlang will install to this location and rabbitmq will use this environment variable to locate it
 # RABBITMQ_VERSION: rabbitmq version used in download url and to rename folder extracted from zip file
 # RABBITMQ_CONFIG_FILE: tell rabbitmq where to find our custom config file
 ENV ERLANG_HOME="c:\\erlang" \
-    RABBITMQ_VERSION="3.10.7" \
+    RABBITMQ_VERSION="3.11.2" \
     RABBITMQ_CONFIG_FILE="c:\\rabbitmq.conf"
 
 # setup powershell options for RUN commands
@@ -19,7 +19,7 @@ EXPOSE 5672 15672
 # download and install erlang using silent install option, and remove installer when done
 # download and extract rabbitmq, and remove zip file when done
 # remove version from rabbitmq folder name
-RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_24.3.4.6.exe" -OutFile "c:\\erlang_install.exe" ; \
+RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_25.1.1.exe" -OutFile "c:\\erlang_install.exe" ; \
         Start-Process -Wait -FilePath "c:\\erlang_install.exe" -ArgumentList /S, /D=$env:ERLANG_HOME ; \
         Remove-Item -Force -Path "C:\\erlang_install.exe" ; \
     Invoke-WebRequest -Uri "https://github.com/rabbitmq/rabbitmq-server/releases/download/v$env:RABBITMQ_VERSION/rabbitmq-server-windows-$env:RABBITMQ_VERSION.zip" -OutFile "c:\\rabbitmq.zip" ; \

--- a/rabbitmq/windows/3.9.22/Dockerfile
+++ b/rabbitmq/windows/3.9.22/Dockerfile
@@ -19,7 +19,7 @@ EXPOSE 5672 15672
 # download and install erlang using silent install option, and remove installer when done
 # download and extract rabbitmq, and remove zip file when done
 # remove version from rabbitmq folder name
-RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_24.3.4.exe" -OutFile "c:\\erlang_install.exe" ; \
+RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_24.3.4.6.exe" -OutFile "c:\\erlang_install.exe" ; \
         Start-Process -Wait -FilePath "c:\\erlang_install.exe" -ArgumentList /S, /D=$env:ERLANG_HOME ; \
         Remove-Item -Force -Path "C:\\erlang_install.exe" ; \
     Invoke-WebRequest -Uri "https://github.com/rabbitmq/rabbitmq-server/releases/download/v$env:RABBITMQ_VERSION/rabbitmq-server-windows-$env:RABBITMQ_VERSION.zip" -OutFile "c:\\rabbitmq.zip" ; \

--- a/rabbitmq/windows/3.9.24/Dockerfile
+++ b/rabbitmq/windows/3.9.24/Dockerfile
@@ -1,14 +1,14 @@
 # ltsc2019 or ltsc2022
-ARG SERVER_VERSION='ltsc2022'  
+ARG SERVER_VERSION='ltsc2022'
 FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
-LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.7"
+LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.9.24"
 
 # ERLANG_HOME: erlang will install to this location and rabbitmq will use this environment variable to locate it
 # RABBITMQ_VERSION: rabbitmq version used in download url and to rename folder extracted from zip file
 # RABBITMQ_CONFIG_FILE: tell rabbitmq where to find our custom config file
 ENV ERLANG_HOME="c:\\erlang" \
-    RABBITMQ_VERSION="3.10.7" \
+    RABBITMQ_VERSION="3.9.24" \
     RABBITMQ_CONFIG_FILE="c:\\rabbitmq.conf"
 
 # setup powershell options for RUN commands

--- a/rabbitmq/windows/latest/Dockerfile
+++ b/rabbitmq/windows/latest/Dockerfile
@@ -2,13 +2,13 @@
 ARG SERVER_VERSION='ltsc2022'  
 FROM mcr.microsoft.com/windows/servercore:${SERVER_VERSION}
 
-LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.10.7"
+LABEL Description="RabbitMQ" Vendor="Pivotal" Version="3.11.2"
 
 # ERLANG_HOME: erlang will install to this location and rabbitmq will use this environment variable to locate it
 # RABBITMQ_VERSION: rabbitmq version used in download url and to rename folder extracted from zip file
 # RABBITMQ_CONFIG_FILE: tell rabbitmq where to find our custom config file
 ENV ERLANG_HOME="c:\\erlang" \
-    RABBITMQ_VERSION="3.10.7" \
+    RABBITMQ_VERSION="3.11.2" \
     RABBITMQ_CONFIG_FILE="c:\\rabbitmq.conf"
 
 # setup powershell options for RUN commands
@@ -19,7 +19,7 @@ EXPOSE 5672 15672
 # download and install erlang using silent install option, and remove installer when done
 # download and extract rabbitmq, and remove zip file when done
 # remove version from rabbitmq folder name
-RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_24.3.4.exe" -OutFile "c:\\erlang_install.exe" ; \
+RUN Invoke-WebRequest -Uri "https://erlang.org/download/otp_win64_25.1.1.exe" -OutFile "c:\\erlang_install.exe" ; \
         Start-Process -Wait -FilePath "c:\\erlang_install.exe" -ArgumentList /S, /D=$env:ERLANG_HOME ; \
         Remove-Item -Force -Path "C:\\erlang_install.exe" ; \
     Invoke-WebRequest -Uri "https://github.com/rabbitmq/rabbitmq-server/releases/download/v$env:RABBITMQ_VERSION/rabbitmq-server-windows-$env:RABBITMQ_VERSION.zip" -OutFile "c:\\rabbitmq.zip" ; \


### PR DESCRIPTION
Change History:

3.9.22   - Updated Erlang to 24.3.4.6
3.9.24   - New - with hotfix
3.10.7   - Updated Erlang to 24.3.4.6
3.10.10 - New version added 
3.11.0   - New version added, release 3.11 with Erlang 25.1.1
3.11.2   - Latest patch of the new release 3.11 with Erlang 25.1.1

Splitted pipeline in to two yaml pipelines:

**- ci-windows-2019.yml**  - specific for Windows 2019 builds
**- ci-windows-latest.yml** - specific for Windows 2022 builds

